### PR TITLE
BaseEntity 선택적 상속

### DIFF
--- a/src/main/java/com/seoultech/ecc/expression/datamodel/ExpressionEntity.java
+++ b/src/main/java/com/seoultech/ecc/expression/datamodel/ExpressionEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.expression.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @Entity
 @Table(name = "expression")
-public class ExpressionEntity extends BaseEntity {
+public class ExpressionEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/seoultech/ecc/study/datamodel/TopicCategoryEntity.java
+++ b/src/main/java/com/seoultech/ecc/study/datamodel/TopicCategoryEntity.java
@@ -1,7 +1,5 @@
 package com.seoultech.ecc.study.datamodel;
 
-import com.seoultech.ecc.admin.dto.EditCategoryDto;
-import com.seoultech.ecc.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,7 +10,7 @@ import lombok.*;
 @Builder
 @Entity
 @Table(name = "topic_category")
-public class TopicCategoryEntity extends BaseEntity {
+public class TopicCategoryEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/seoultech/ecc/study/datamodel/TopicEntity.java
+++ b/src/main/java/com/seoultech/ecc/study/datamodel/TopicEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.study.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -11,7 +10,7 @@ import lombok.*;
 @Builder
 @Entity
 @Table(name = "topic")
-public class TopicEntity extends BaseEntity {
+public class TopicEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "topic_id")

--- a/src/main/java/com/seoultech/ecc/team/datamodel/ApplyRegularSubjectEntity.java
+++ b/src/main/java/com/seoultech/ecc/team/datamodel/ApplyRegularSubjectEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.team.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import com.seoultech.ecc.member.datamodel.MemberEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +11,7 @@ import lombok.*;
 @Builder
 @Entity
 @Table(name = "apply_regular_subject")
-public class ApplyRegularSubjectEntity extends BaseEntity {
+public class ApplyRegularSubjectEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/seoultech/ecc/team/datamodel/ApplyRegularTimeEntity.java
+++ b/src/main/java/com/seoultech/ecc/team/datamodel/ApplyRegularTimeEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.team.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import com.seoultech.ecc.member.datamodel.MemberEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +11,7 @@ import lombok.*;
 @Builder
 @Entity
 @Table(name = "apply_regular_time")
-public class ApplyRegularTimeEntity extends BaseEntity {
+public class ApplyRegularTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/seoultech/ecc/team/datamodel/TeamMemberEntity.java
+++ b/src/main/java/com/seoultech/ecc/team/datamodel/TeamMemberEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.team.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import com.seoultech.ecc.member.datamodel.MemberEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -13,7 +12,7 @@ import lombok.Setter;
         name = "team_member",
         uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "team_id"})
 )
-public class TeamMemberEntity extends BaseEntity {
+public class TeamMemberEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/seoultech/ecc/team/datamodel/TimeEntity.java
+++ b/src/main/java/com/seoultech/ecc/team/datamodel/TimeEntity.java
@@ -1,6 +1,5 @@
 package com.seoultech.ecc.team.datamodel;
 
-import com.seoultech.ecc.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @Entity
 @Table(name = "time")
-public class TimeEntity extends BaseEntity {
+public class TimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
데이터베이스 리소스 절약 및 성능 향상을 위해 member, team, level_change_request, major, subject, one_time_team_info 테이블만 BaseEntity를 extends 하도록 수정했습니다. 