### PR TITLE
[Fix/deploy] EC2 배포 성능 최적화 및 메모리 사용량 개선

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -27,8 +27,20 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # GitHub Actions에서 빌드
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build -x test --no-daemon
+        timeout-minutes: 10
+
+      # 빌드된 JAR 파일을 EC2로 전송
+      - name: Copy JAR to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "build/libs/*.jar"
+          target: "~/ecc-back/"
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v0.1.6
@@ -36,13 +48,14 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          timeout: 300s
           script: |
             echo "🚀 Starting deployment..."
             
             # Navigate to project directory
             cd ~/ecc-back
             
-            # Pull latest code
+            # Pull latest code (docker-compose.yml 등을 위해)
             echo "📡 Pulling latest code..."
             git pull origin main
             
@@ -50,13 +63,38 @@ jobs:
             echo "🔧 Loading environment variables..."
             source ~/load-env.sh
             
-            # Stop existing containers
-            echo "🛑 Stopping existing containers..."
-            docker compose down
+            # 강제로 기존 컨테이너 및 리소스 정리
+            echo "🛑 Stopping and cleaning existing containers..."
+            docker compose down || true
+            docker stop $(docker ps -q) 2>/dev/null || true
+            docker rm $(docker ps -aq) 2>/dev/null || true
             
-            # Build and start new containers
-            echo "🐳 Building and starting containers..."
-            docker compose up --build -d
+            # 8080 포트 사용 중인 프로세스 강제 종료
+            echo "🔫 Killing processes on port 8080..."
+            sudo pkill -f "java.*8080" || true
+            sudo fuser -k 8080/tcp || true
+            
+            # Docker 시스템 정리 (이미지는 유지)
+            echo "🧹 Cleaning Docker system..."
+            docker container prune -f
+            docker volume prune -f
+            
+            # 메모리 상태 확인
+            echo "💾 Memory status before deployment:"
+            free -h
+            
+            # JAR 파일이 있는지 확인
+            if [ -f build/libs/*.jar ]; then
+              echo "✅ JAR file found"
+              ls -la build/libs/
+            else
+              echo "❌ JAR file not found"
+              exit 1
+            fi
+            
+            # 빌드 없이 컨테이너 시작 (--build 제거)
+            echo "🐳 Starting containers (no build)..."
+            docker compose up -d
             
             # Wait for containers to start
             echo "⏳ Waiting for containers to start..."
@@ -66,12 +104,30 @@ jobs:
             echo "✅ Checking container status..."
             docker compose ps
             
-            # API 상태 확인 (적절한 에러 처리)
-            echo "🩺 API 상태 확인 중..."
-            if curl -f -s http://localhost:8080/api/major; then
-              echo "✅ API 상태 확인 성공"
-            else
-              echo "❌ API 상태 확인 실패"
-            fi
+            # 메모리 상태 재확인
+            echo "💾 Memory status after deployment:"
+            free -h
             
-            echo "🎉 Deployment completed!"
+            # Docker stats 확인
+            echo "📊 Container resource usage:"
+            timeout 10s docker stats --no-stream || true
+            
+            # API 상태 확인 (여러 번 시도)
+            echo "🩺 API 상태 확인 중..."
+            for i in {1..5}; do
+              if curl -f -s http://localhost:8080/api/major; then
+                echo "✅ API 상태 확인 성공 (시도 $i)"
+                break
+              else
+                echo "⏳ API 준비 중... (시도 $i/5)"
+                sleep 10
+              fi
+            done
+            
+            # 최종 확인
+            if curl -f -s http://localhost:8080/api/major >/dev/null; then
+              echo "🎉 Deployment completed successfully!"
+            else
+              echo "❌ Deployment completed but API is not responding"
+              exit 1
+            fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,15 @@
-# 멀티스테이지 빌드 - 빌드 단계
-FROM gradle:8.7-jdk17 AS build
-WORKDIR /app
-
-# Gradle 설정 파일들 먼저 복사 (캐시 최적화)
-COPY build.gradle settings.gradle ./
-COPY gradle/ gradle/
-COPY gradlew ./
-
-# 의존성만 먼저 다운로드 (캐시 레이어)
-RUN gradle dependencies --no-daemon
-
-# 소스 코드 복사
-COPY src/ src/
-
-# 빌드 실행 (테스트 제외)
-RUN gradle clean build -x test --no-daemon
-
-# 실행 단계
+# 단일 스테이지: 실행만
 FROM openjdk:17-jdk-slim
+
 WORKDIR /app
 
-# 빌드 단계에서 생성된 JAR 파일 복사
-COPY --from=build /app/build/libs/*.jar app.jar
+# GitHub Actions에서 이미 빌드된 JAR 파일을 단순 복사
+COPY build/libs/*.jar app.jar
 
-# 포트 노출
+# JVM 메모리 제한 설정
+ENV JAVA_OPTS="-Xmx350m -Xms150m"
+
 EXPOSE 8080
 
-# 실행 명령
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# 환경변수를 사용하여 JVM 옵션 적용
+CMD ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
EC2 메모리 부족 & Gradle 빌드 타임아웃 문제로 인한 배포 실패의 가장 큰 원인이 Java 프로세스 중복 실행 문제였습니다. 
<img width="1568" height="765" alt="image" src="https://github.com/user-attachments/assets/70678816-5bd9-4455-981a-6090d47cff3d" />


변경사항
## 1. GitHub Actions 배포 스크립트 개선 (deploy-backend.yml)
- 빌드 위치를 EC2에서 Github Actions로 변경했습니다.
- 기존 컨테이너 및 프로세스를 완전 정리하는 명령어를 추가했습니다.

## 2. Dockerfile 최적화
- 멀티스테이지 빌드 제거: EC2에서의 Gradle 빌드 과정 제거, Github Actions에서 빌드된 JAR 파일만 복사


✔️ Before
`GitHub Actions → 코드만 EC2로 전송 (git pull)
                ↓
EC2에서 Gradle 빌드 (메모리 많이 사용)
                ↓
Docker 이미지 생성 후 실행`

✔️ After
`GitHub Actions → JAR 파일 빌드 (충분한 리소스)
                ↓
scp-action → 빌드된 JAR을 EC2로 전송
                ↓
EC2에서 JAR만 가지고 Docker 실행 (빠름)`